### PR TITLE
Rewrite computable dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+* Rewrite the recomputable dependency graph.
+
 ## 3.0.1
 
 * Fix bug with computable builder factory disposing computables unnecessarily.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -86,18 +86,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -126,18 +126,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.14.0"
   path:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.1"
   vector_math:
     dependency: transitive
     description:
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/computable.dart
+++ b/lib/computable.dart
@@ -67,7 +67,7 @@ class Computable<T> {
     _value = updatedValue;
 
     for (final dep in _dependents) {
-      dep._dirty();
+      dep._dirty(true);
     }
 
     final controller = _controller;

--- a/lib/computable.dart
+++ b/lib/computable.dart
@@ -20,10 +20,14 @@ class Computable<T> {
   /// Whether duplicate values should be discarded and not re-emitted to subscribers.
   final bool dedupe;
 
+  /// Whether the [Computable] must always be re-evaluated when checking if it is dirty.
+  bool deepDirtyCheck;
+
   Computable(
     this._value, {
     this.broadcast = false,
     this.dedupe = true,
+    this.deepDirtyCheck = false,
   });
 
   void _initController() {
@@ -35,7 +39,7 @@ class Computable<T> {
 
     _stream = StreamFactory(() {
       return _controller!.stream.startWith(_value);
-    });
+    }, broadcast);
   }
 
   /// Private constructor used by [Computation] and [ComputationTransform] to instantiate a [Computable]
@@ -43,6 +47,7 @@ class Computable<T> {
   Computable._({
     this.broadcast = false,
     this.dedupe = true,
+    this.deepDirtyCheck = false,
   });
 
   void dispose() {

--- a/lib/computation.dart
+++ b/lib/computation.dart
@@ -11,24 +11,17 @@ class Computation<T> extends Computable<T> with Recomputable<T> {
     super.broadcast = false,
     super.dedupe = false,
   }) : super._() {
-    for (final computable in computables) {
-      _dependencies.add(computable);
-      computable._dependents.add(this);
-    }
-
-    _value = _recompute();
+    init(computables);
   }
 
   @override
   T _recompute() {
-    return compute(
-      _dependencies.map((computable) => computable.get()).toList(),
-    );
+    return compute(_deps.map((computable) => computable.get()).toList());
   }
 
   @override
   dispose() {
-    for (final dep in _dependencies) {
+    for (final dep in _deps) {
       if (!dep.broadcast) {
         dep.dispose();
       } else {

--- a/lib/computation_transform.dart
+++ b/lib/computation_transform.dart
@@ -14,9 +14,7 @@ class ComputationTransform<T> extends Computable<T> with Recomputable<T> {
   })  : _computation =
             Computation(computables: computables, compute: transform),
         super._() {
-    _computation._dependents.add(this);
-    _dependencies.add(_computation);
-    _value = _recompute();
+    init([_computation]);
   }
 
   @override
@@ -34,12 +32,11 @@ class ComputationTransform<T> extends Computable<T> with Recomputable<T> {
 
     if (_innerComputable != null) {
       _innerComputable!.dispose();
-      _dependencies.remove(innerComputable);
+      _removeDep(_innerComputable!);
     }
 
     _innerComputable = innerComputable;
-    innerComputable._dependents.add(this);
-    _dependencies.add(innerComputable);
+    _addDep(innerComputable);
 
     return innerComputable.get();
   }

--- a/lib/computation_transform.dart
+++ b/lib/computation_transform.dart
@@ -25,17 +25,21 @@ class ComputationTransform<T> extends Computable<T> with Recomputable<T> {
 
     /// A computation transform could be recomputing because either its inner computable
     /// has emitted a new value or its inner computable has changed. If the inner computable has changed,
-    /// then it disposes the previous inner computable and switches to the new one.
+    /// then it disposes the previous inner computable, removing it from its dependencies and switches to the new one.
     ///
     /// In either scenario, it then returns the inner computable's latest value.
     if (identical(innerComputable, _innerComputable)) {
       return innerComputable.get();
     }
 
-    _innerComputable?.dispose();
-    _innerComputable = innerComputable;
+    if (_innerComputable != null) {
+      _innerComputable!.dispose();
+      _dependencies.remove(innerComputable);
+    }
 
+    _innerComputable = innerComputable;
     innerComputable._dependents.add(this);
+    _dependencies.add(innerComputable);
 
     return innerComputable.get();
   }

--- a/lib/extensions/stream/stream_factory.dart
+++ b/lib/extensions/stream/stream_factory.dart
@@ -3,8 +3,14 @@ part of computables;
 /// Returns a new stream produced by calling [factory] whenever a listener subscribes to the [StreamFactory].
 class StreamFactory<T> extends Stream<T> {
   final Stream<T> Function() factory;
+  final bool _isBroadcast;
 
-  StreamFactory(this.factory);
+  StreamFactory(this.factory, this._isBroadcast);
+
+  @override
+  get isBroadcast {
+    return _isBroadcast;
+  }
 
   @override
   StreamSubscription<T> listen(

--- a/lib/recomputable.dart
+++ b/lib/recomputable.dart
@@ -25,13 +25,8 @@ mixin Recomputable<T> on Computable<T> {
       // 2. It frees up the main isolate to process other pending events before having to perform what could
       //    be a heavy recomputation.
       Future.delayed(Duration.zero, () {
-        // When the dirty computable's asynchronous recomputation is later run, it may no longer be necessary
-        // to recompute, since if the dirty computable's value had been accessed synchronously before it could
-        // process its async recomputation, it would've updated synchronously and marked itself as no longer dirty.
-        if (isDirty) {
-          _isDirty = false;
-          add(_recompute());
-        }
+        _isDirty = false;
+        add(_recompute());
       });
     }
   }
@@ -41,8 +36,7 @@ mixin Recomputable<T> on Computable<T> {
     // Since recomputations of dirty computables are performed asynchronously, if the value of a dirty
     // computable is accessed before it has been recomputed, then it must be recomputed synchronously.
     if (isDirty) {
-      _isDirty = false;
-      return add(_recompute());
+      return _recompute();
     }
 
     return _value;

--- a/lib/recomputable.dart
+++ b/lib/recomputable.dart
@@ -64,7 +64,7 @@ mixin Recomputable<T> on Computable<T> {
       // A dirty recomputable is scheduled for recomputation asynchronously. This has a couple advantages:
       //
       // 1. It batches together synchronous updates to multiple dependencies into a single recomputation.
-      // 2. It frees up the main thread to process other pending events before having to perform what could
+      // 2. It frees up the main isolate to process other pending events before having to perform what could
       //    be a heavy recomputation.
       if (!_isScheduled) {
         _isScheduled = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: computables
 description: Computables are composable, streamable values.
-version: 3.0.1
+version: 4.0.0
 homepage: https://github.com/danReynolds/computables
 
 environment:

--- a/test/computables_test.dart
+++ b/test/computables_test.dart
@@ -257,6 +257,23 @@ void main() {
 
       expect(computation.get(), 6);
     });
+
+    test('Returns updated values from a dirty inner computable', () {
+      final computable = Computable(1);
+      final computable2 = Computable(2);
+
+      final computation = computable.transform(
+        (input1) {
+          return computable2.map((input2) => input1 + input2);
+        },
+      );
+
+      expect(computation.get(), 3);
+
+      computable2.add(5);
+
+      expect(computation.get(), 6);
+    });
   });
 
   group('Subscriber', () {

--- a/test/computables_test.dart
+++ b/test/computables_test.dart
@@ -9,6 +9,13 @@ void main() {
       expect(Computable(2).get(), 2);
     });
 
+    test('add', () {
+      final computable = Computable(2);
+      expect(computable.get(), 2);
+      computable.add(3);
+      expect(computable.get(), 3);
+    });
+
     group("stream", () {
       test('Emits values on the stream', () {
         final computable = Computable(2);
@@ -72,7 +79,7 @@ void main() {
 
       await Future.delayed(const Duration(milliseconds: 1));
 
-      // Ignores intermediate values.
+      // Does not emit intermediate values.
       computable.add(2);
 
       computable.add(3);
@@ -111,9 +118,9 @@ void main() {
   });
 
   group(
-    'Computations',
+    'Computation',
     () {
-      test('compute multiple inputs', () async {
+      test('computes multiple inputs', () async {
         final computable1 = Computable(0);
         final computable2 = Computable(0);
 
@@ -246,13 +253,9 @@ void main() {
         },
       );
 
-      expect(computation.get(), 1);
-
       final future = computation.stream().take(2).toList();
 
       computable2.add(5);
-
-      expect(computation.get(), 4);
 
       expect(await future, [1, 4]);
     });

--- a/test/computables_test.dart
+++ b/test/computables_test.dart
@@ -9,13 +9,31 @@ void main() {
       expect(Computable(2).get(), 2);
     });
 
-    test("stream", () {
-      final computable = Computable(2);
+    group("stream", () {
+      test('Emits values on the stream', () {
+        final computable = Computable(2);
 
-      expectLater(computable.stream(), emitsInOrder([2, 4, 6]));
+        expectLater(computable.stream(), emitsInOrder([2, 4, 6]));
 
-      computable.add(4);
-      computable.add(6);
+        computable.add(4);
+        computable.add(6);
+      });
+
+      test(
+        'Is a non-broadcast stream by default',
+        () {
+          final computable = Computable(2);
+          expect(computable.stream().isBroadcast, false);
+        },
+      );
+
+      test(
+        'Is a broadcast stream when specified',
+        () {
+          final computable = Computable(2, broadcast: true);
+          expect(computable.stream().isBroadcast, true);
+        },
+      );
     });
 
     test('map', () async {
@@ -65,7 +83,7 @@ void main() {
       expectLater(computable.stream(), emitsInOrder([null]));
     });
 
-    test("Ignores duplicates by default", () {
+    test("ignores duplicates by default", () {
       final computable = Computable(1);
 
       expectLater(
@@ -78,7 +96,7 @@ void main() {
       computable.add(3);
     });
 
-    test("Re-emits duplicates when specified", () {
+    test("re-emits duplicates when specified", () {
       final computable = Computable(1, dedupe: false);
 
       expectLater(
@@ -95,7 +113,7 @@ void main() {
   group(
     'Computations',
     () {
-      test('Computes multiple inputs', () async {
+      test('compute multiple inputs', () async {
         final computable1 = Computable(0);
         final computable2 = Computable(0);
 
@@ -128,7 +146,7 @@ void main() {
         );
       });
 
-      test('Does not broadcast intermediate values from the same task',
+      test('does not broadcast intermediate values from the same task',
           () async {
         final computable1 = Computable(0);
         final computable2 = Computable(0);
@@ -150,7 +168,7 @@ void main() {
         expect(await future, [0, 2]);
       });
 
-      test('Recomputes immediately if accessed synchronously', () {
+      test('recomputes immediately if accessed synchronously', () {
         final computable = Computable(1);
 
         final computation = computable.map((value) => value + 1);
@@ -165,7 +183,7 @@ void main() {
         expect(computation.get(), 6);
       });
 
-      test("Cancels non-broadcast computables automatically", () async {
+      test("cancels non-broadcast computables automatically", () async {
         final computable1 = Computable(1);
         final computable2 = Computable(2);
         final computation = Computable.compute2(
@@ -180,7 +198,7 @@ void main() {
         expect(computable2.isClosed, true);
       });
 
-      test("Does not cancel broadcast computables automatically", () async {
+      test("does not cancel broadcast computables automatically", () async {
         final computable1 = Computable(1, broadcast: true);
         final computable2 = Computable(2);
 
@@ -198,7 +216,7 @@ void main() {
         computable1.dispose();
       });
 
-      test('Immediately returns updated values', () {
+      test('immediately returns updated values', () {
         final computable1 = Computable(1);
         final computable2 = Computable(2);
 
@@ -216,7 +234,7 @@ void main() {
   );
 
   group("Transforms", () {
-    test('Emits values from the inner computable', () async {
+    test('emits values from the inner computable', () async {
       final computable = Computable(1);
       final computable2 = Computable(2);
 
@@ -239,7 +257,7 @@ void main() {
       expect(await future, [1, 4]);
     });
 
-    test('Immediately returns updated values', () {
+    test('immediately returns updated values', () {
       final computable = Computable(1);
       final computable2 = Computable(2);
 
@@ -258,7 +276,7 @@ void main() {
       expect(computation.get(), 6);
     });
 
-    test('Returns updated values from a dirty inner computable', () {
+    test('returns updated values from a dirty inner computable', () {
       final computable = Computable(1);
       final computable2 = Computable(2);
 
@@ -277,7 +295,7 @@ void main() {
   });
 
   group('Subscriber', () {
-    test('Forwards computable', () async {
+    test('forwards computable', () async {
       final subscriber = Computable.subscriber(0);
 
       subscriber.forward(Computable(1));
@@ -285,7 +303,7 @@ void main() {
       expect(subscriber.get(), 1);
     });
 
-    test('Subscribes to computable', () async {
+    test('subscribes to computable', () async {
       int result = 0;
       final subscriber = Computable.subscriber(0);
 
@@ -296,7 +314,7 @@ void main() {
       expect(result, 1);
     });
 
-    test('Forwards stream', () {
+    test('forwards stream', () {
       final subscriber = Computable.subscriber(0);
 
       subscriber.forwardStream(Stream.value(1));
@@ -307,7 +325,7 @@ void main() {
       );
     });
 
-    test('Forwards future', () {
+    test('forwards future', () {
       final subscriber = Computable.subscriber(0);
 
       subscriber.forwardFuture(Future.value(1));


### PR DESCRIPTION
Rewrite of the computable dependency graph from to support deep dirty checking and fixes some issues with computable dependency recalculation.